### PR TITLE
Make sure if SHOT fails to read ply file, it will not crash.

### DIFF
--- a/src/SHOTMain.cpp
+++ b/src/SHOTMain.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
 	vtkPolyData* mesh = LoadPolyData(params.datapath);
 	cleanPolyData(mesh);
 
-	if (mesh)
+    if (mesh->GetNumberOfPoints())
 	{
 		double meshRes = computeMeshResolution(mesh);
 


### PR DESCRIPTION
When I run this code, no matter whether the ply file is read successfully, if(mesh) always gives true. So I made this modification.